### PR TITLE
Quick quality of life fixes for CHM343 students

### DIFF
--- a/molcalc/static/js/app.js
+++ b/molcalc/static/js/app.js
@@ -403,7 +403,7 @@ function jsmolSetMol(canvasObj, molStr)
 {
     // http://wiki.jmol.org/index.php/File_formats/Chemical_Structure
 
-    jsmolCmd(canvasObj, "load inline '"+molStr+"'");
+    jsmolCmd(canvasObj, "load inline '"+molStr+"'; zoom 75");
     // jsmolCmd(canvasObj, "minimize addHydrogens");
 
     return false;

--- a/molcalc/templates/jsmol_toolbar.html
+++ b/molcalc/templates/jsmol_toolbar.html
@@ -14,6 +14,7 @@
 
   <ul>
     <li class="action minimize"><a rel="" class="button highlight">Quick Minimize</a></li>
+    <li><a href="#" class="button getName highlight">Get Molecule Name</a></li>
     <!-- <li class="action minimize"><a class="button icon"><i class="fas fa&#45;undo"></i></a></li> -->
     <!-- <li class="action minimize"><a class="button icon"><i class="fas fa&#45;redo"></i></a></li> -->
   </ul>

--- a/molcalc/templates/page_editor.html
+++ b/molcalc/templates/page_editor.html
@@ -219,7 +219,7 @@ $$$$
             <ul class="bottombar">
 
                 <li><a href="#" class="button quantum highlight">Calculate Properties</a></li>
-                <li><a download href="../static/img/benzene_v1_5.png" class="button"><i class="fa fa-download"></i> Download Inputs</a></li>
+<!--                <li><a download href="../static/img/benzene_v1_5.png" class="button"><i class="fa fa-download"></i> Download Inputs</a></li>-->
             </ul>
         </section>
 

--- a/molcalc/templates/page_editor.html
+++ b/molcalc/templates/page_editor.html
@@ -219,9 +219,11 @@ $$$$
             <ul class="bottombar">
 
                 <li><a href="#" class="button quantum highlight">Calculate Properties</a></li>
-                <li><a href="#" class="button getName highlight">Get Molecule Name</a></li>
+                <li><a download href="../static/img/benzene_v1_5.png" class="button"><i class="fa fa-download"></i> Download Inputs</a></li>
             </ul>
         </section>
+
+
 
 
     </section>

--- a/molcalc/views.py
+++ b/molcalc/views.py
@@ -113,7 +113,7 @@ def page_help(request):
 def ajax_sdf_to_smiles(request):
     """
 
-    sdf to smiles convertion
+    sdf to smiles conversion
 
     """
     return {"message", "disabled"}

--- a/molcalc/views.py
+++ b/molcalc/views.py
@@ -263,12 +263,12 @@ def ajax_submitquantum(request):
 
     # TODO Check lengths of atoms
     # TODO Define max in settings
-    max_atoms = 25
+    max_atoms = 50
     (heavy_atoms,) = np.where(atoms != 1)
     if len(heavy_atoms) > max_atoms:
         return {
             "error": "Error 194 - max atoms error",
-            "message": "Stop Casper. Max ten heavy atoms.",
+            "message": f"Stop Casper. Max {max_atoms} heavy atoms.",
         }
 
     # Fix sdfstr

--- a/molcalc_lib/gamess_calculations.py
+++ b/molcalc_lib/gamess_calculations.py
@@ -6,7 +6,7 @@ import ppqm
 
 _logger = logging.getLogger("molcalc:calc")
 
-MAX_TIME = 20  # seconds
+MAX_TIME = 30  # seconds
 
 
 def optimize_coordinates(molobj, gamess_options):

--- a/molcalc_lib/gamess_calculations.py
+++ b/molcalc_lib/gamess_calculations.py
@@ -6,7 +6,7 @@ import ppqm
 
 _logger = logging.getLogger("molcalc:calc")
 
-MAX_TIME = 30  # seconds
+MAX_TIME = 60  # seconds
 
 
 def optimize_coordinates(molobj, gamess_options):
@@ -14,7 +14,7 @@ def optimize_coordinates(molobj, gamess_options):
     calculation_options = {
         "basis": {"gbasis": theory_level},
         "contrl": {"runtyp": "optimize"},
-        "statpt": {"opttol": 0.0005, "nstep": 500, "projct": False},
+        "statpt": {"opttol": 0.00025, "nstep": 500, "projct": False},
     }
 
     gamess_options.get("filename", None)
@@ -44,7 +44,8 @@ def calculate_vibrations(molobj, gamess_options):
     else:
         calculation_options = {
             "basis": {"gbasis": theory_level},
-            "contrl": {"runtyp": "hessian", "maxit": 60},
+            "contrl": {"runtyp": "hessian", "maxit": 100},
+            "force": {"method": "seminum"},
         }
 
     calc_obj = ppqm.gamess.GamessCalculator(**gamess_options)
@@ -156,6 +157,5 @@ def calculate_all_properties(molobj, gamess_options, async_calc=False):
             gamess_options = copy.deepcopy(gamess_options)
             gamess_options["filename"] = filename + "_" + func.__name__
             properties.append( func(molobj, gamess_options) )
-
 
     return properties


### PR DESCRIPTION
* Moved "Get Molecule Name" button to top of editor sidebar
* Increased maximum number of heavy atoms allowed in calculation to 50
* Increased maximum calculation time to 1 minute
* Force-set JSmol to "zoom 75" upon loading molecule